### PR TITLE
Add local link to ContactSection in LandingPage.jsx

### DIFF
--- a/src/components/Carrousel.jsx
+++ b/src/components/Carrousel.jsx
@@ -9,7 +9,7 @@ const slides = [
         color: "#A82428A1",
         buttonText: "Contáctanos",
         buttonColor: "bg-fara-gold",
-        link: "/#",
+        link: "/#contacto",
     },
     {
         image: img2,

--- a/src/components/ContactSection.jsx
+++ b/src/components/ContactSection.jsx
@@ -13,7 +13,10 @@ export function ContactSection() {
     /* Seccion de contacto */
 
     return (
-        <div className="bg-fara-strong-red flex w-full flex-col justify-center gap-9 p-10 text-white md:flex-row md:gap-18 md:p-20">
+        <section
+            id="contacto"
+            className="bg-fara-strong-red flex w-full flex-col justify-center gap-9 p-10 text-white md:flex-row md:gap-18 md:p-20"
+        >
             {/* Contacto */}
             <div className="text-center md:text-left">
                 <h2 className="mb-4 text-xl font-bold uppercase lg:text-3xl">Contacto institucional</h2>
@@ -125,6 +128,6 @@ export function ContactSection() {
                     </Link>
                 </nav>
             </div>
-        </div>
+        </section>
     )
 }

--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -3,10 +3,23 @@ import { useLocation } from "react-router"
 import { AcercaDe, ServiciosSection, DonarSection, AliadosSection, Areas, Carrousel, Layout } from "../components/index"
 
 export function LandingPage() {
-    const { pathname } = useLocation()
+    const { pathname, hash } = useLocation()
+
     useEffect(() => {
         window.scrollTo(0, 0)
     }, [pathname])
+
+    useEffect(() => {
+        if (hash) {
+            const element = document.getElementById(hash.replace("#", ""))
+            if (element) {
+                element.scrollIntoView()
+                // Si bien se puede usar { behavior: "smooth" } para dar una animación
+                // lamentablemente no es accesible por la falta de control nativo que
+                // nos permita ajustarlo acorde a los estándares de accesibilidad.
+            }
+        }
+    }, [hash])
 
     return (
         <Layout>


### PR DESCRIPTION
Even if this implementation could be made without using React Router, in this case it takes adavatage of `useLocation()` that was already being used, in order to make this local link so the user can be moved towards the `ContactSection` component inside the landing page.

It's worth noting that `{ behavior: "smooth" }` was not used for this scroll movement due to potencial accesibility issues (if the page is long enough, the scroll speed could be too fast for photoepileptic people), and it is easier to just not use this instead of making the entire site respond to `prefers-reduced-motion` media.