### PR TITLE
fix(a11y): Invalid HTML and critical ARIA fixes — PR 1

### DIFF
--- a/src/components/sectionsFaraGenero/EquipoDiciplinario.jsx
+++ b/src/components/sectionsFaraGenero/EquipoDiciplinario.jsx
@@ -1,0 +1,105 @@
+import React from 'react'
+
+const equipoDiciplinario = [
+  {
+    id: 0,
+    nombre: "Dra. Silvina M. Paz",
+    rol: "Dirección académica e institucional",
+    image: "/src/assets/integrantes/SilvinaPaz.webp",
+    description: "Abogada con sólida formación en Derechos Humanos y Justicia Restaurativa",
+    linkedIn: "/link",
+    linkX: "/X"
+  },
+  {
+    id: 1,
+    nombre: "Dra. Silvana S. Paz",
+    rol: "Dirección académica e institucional",
+    image: "/src/assets/integrantes/SilvanaPaz.webp",
+    description: "Abogada con sólida formación en Derechos Humanos y Justicia Restaurativa",
+    linkedIn: "/link",
+    linkX: "/X"
+  },
+  {
+    id: 2,
+    nombre: "Lic. Constanza Ochoa",
+    rol: "Docente",
+    image: "/src/assets/integrantes/Constanza.webp",
+    description: "Psicóloga, trabaja en clínica con adolescentes y adultos desde un enfoque interdisciplinario",
+    linkedIn: "/link",
+    linkX: "/X"
+  },
+  {
+    id: 3,
+    nombre: "Lic. Alejandra Barranquero",
+    rol: "Docente",
+    image: "/src/assets/integrantes/AlejandraBarranquero.webp",
+    description: "Artista plástica y educadora que impulsa procesos creativos con compromiso social",
+    linkedIn: "/link",
+    linkX: "/X"
+  },
+  {
+    id: 4,
+    nombre: "Lic. Eliana Catogio",
+    rol: "Docente",
+    image: "https://randomuser.me/api/portraits/men/75.jpg",
+    description: "Description",
+    linkedIn: "/link",
+    linkX: "/X"
+  },
+  {
+    id: 5,
+    nombre: "Lic. Eliana Servera",
+    rol: "Docente",
+    image: "https://randomuser.me/api/portraits/men/75.jpg",
+    description: "Description",
+    linkedIn: "/link",
+    linkX: "/X"
+  },
+  {
+    id: 6,
+    nombre: "Lic. Cynthia Beilis",
+    rol: "Docente",
+    image: "/src/assets/integrantes/Cintia.webp",
+    description: "Formada en Administración de Empresas, Derecho y Psicología de la Familia. Especializada en gestión de recursos y alianzas institucionales",
+    linkedIn: "/link",
+    linkX: "/X"
+  },
+]
+
+export function EquipoDiciplinario() {
+  return (
+    <section className="flex flex-col justify-center items-center w-full gap-16 py-12 px-10 md:py-20 md:px-32">
+      <div className="flex flex-col items-center justify-center">
+        <h2 className="text-xl font-bold md:text-2xl lg:text-5xl mb-5 text-center">
+          Nuestro Equipo
+        </h2>
+        <p className="text-lg text-center max-w-4xl md:text-xl lg:text-2xl">
+          El área está integrada por profesionales del derecho, la psicología, el trabajo social, la educación y la facilitación restaurativa, con trayectoria territorial, académica e institucional.
+        </p>
+      </div>
+
+      <div className="grid gap-x-4 gap-y-8 md:grid-cols-3 lg:grid-cols-4 max-w-5xl">
+        {equipoDiciplinario.map((integrante) =>
+          <div className="text-center" key={integrante.id}>
+            <div className="overflow-hidden rounded-full w-30 h-30 m-auto flex items-center justify-center">
+              <img src={integrante.image} alt={integrante.nombre} className="" />
+            </div>
+            <div className="flex flex-col mt-6">
+              <span className="text-xl font-bold">{integrante.nombre}</span>
+              <span className="text-lg font-medium">{integrante.rol}</span>
+            </div>
+            <p className="text-base mt-4">{integrante.description}</p>
+            <div className="flex justify-center gap-2 mt-6">
+              <a href={integrante.linkedIn} aria-label={`${integrante.nombre} en LinkedIn`}>
+                <svg aria-hidden="true" focusable="false" preserveAspectRatio="xMidYMid" width={20} height={20} viewBox="0 0 256 256"><path d="M218.123 218.127h-37.931v-59.403c0-14.165-.253-32.4-19.728-32.4-19.756 0-22.779 15.434-22.779 31.369v60.43h-37.93V95.967h36.413v16.694h.51a39.907 39.907 0 0 1 35.928-19.733c38.445 0 45.533 25.288 45.533 58.186l-.016 67.013ZM56.955 79.27c-12.157.002-22.014-9.852-22.016-22.009-.002-12.157 9.851-22.014 22.008-22.016 12.157-.003 22.014 9.851 22.016 22.008A22.013 22.013 0 0 1 56.955 79.27m18.966 138.858H37.95V95.967h37.97v122.16ZM237.033.018H18.89C8.58-.098.125 8.161-.001 18.471v219.053c.122 10.315 8.576 18.582 18.89 18.474h218.144c10.336.128 18.823-8.139 18.966-18.474V18.454c-.147-10.33-8.635-18.588-18.966-18.453" fill="#0A66C2" /></svg>
+              </a>
+              <a href={integrante.linkX} aria-label={`${integrante.nombre} en X`}>
+                <svg aria-hidden="true" focusable="false" fill="none" width={20} height={20} viewBox="0 0 1200 1227"><path fill="#000" d="M714.163 519.284 1160.89 0h-105.86L667.137 450.887 357.328 0H0l468.492 681.821L0 1226.37h105.866l409.625-476.152 327.181 476.152H1200L714.137 519.284h.026ZM569.165 687.828l-47.468-67.894-377.686-540.24h162.604l304.797 435.991 47.468 67.894 396.2 566.721H892.476L569.165 687.854v-.026Z" /></svg>
+              </a>
+            </div>
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/components/sectionsFaraGenero/LineaDeTrabajo.jsx
+++ b/src/components/sectionsFaraGenero/LineaDeTrabajo.jsx
@@ -1,0 +1,66 @@
+import React from 'react'
+
+export function LineaDeTrabajo() {
+  return (
+    <section className="flex flex-col justify-center items-center gap-4 py-12 px-10 md:py-20 md:px-32">
+      <h2 className="text-xl font-bold md:text-2xl lg:text-5xl mb-5 text-center">
+        Nuestras Líneas de Trabajo
+      </h2>
+
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <article className="border-2 border-fara-blue text-fara-blue px-4 py-5 text-base shadow-md transition-colors lg:p-8 md:text-xl hover:bg-fara-blue hover:text-white duration-300">
+          <div className="flex flex-col justify-center items-center gap-3 lg:flex-row">
+            <svg className="flex-1" xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 24 24"><title>Baseline Support Agent SVG Icon</title><path fill="currentColor" d="M21 12.22C21 6.73 16.74 3 12 3c-4.69 0-9 3.65-9 9.28c-.6.34-1 .98-1 1.72v2c0 1.1.9 2 2 2h1v-6.1c0-3.87 3.13-7 7-7s7 3.13 7 7V19h-8v2h8c1.1 0 2-.9 2-2v-1.22c.59-.31 1-.92 1-1.64v-2.3c0-.7-.41-1.31-1-1.62" /><circle cx="9" cy="13" r="1" fill="currentColor" /><circle cx="15" cy="13" r="1" fill="currentColor" /><path fill="currentColor" d="M18 11.03A6.04 6.04 0 0 0 12.05 6c-3.03 0-6.29 2.51-6.03 6.45a8.07 8.07 0 0 0 4.86-5.89c1.31 2.63 4 4.44 7.12 4.47" /></svg>
+
+            <div className="flex flex-col justify-center gap-2 lg:flex-2">
+              <h3 className="font-bold">A. Acompañamiento</h3>
+              <p>Acompañamiento integral a personas en
+                situación de violencia y/o vulnerabilidad.</p>
+            </div>
+          </div>
+        </article>
+        <article className="border-2 border-fara-blue text-fara-blue px-4 py-5 text-base shadow-md transition-colors lg:p-8 md:text-xl hover:bg-fara-blue hover:text-white duration-300">
+          <div className="flex flex-col justify-center items-center gap-3 lg:flex-row">
+            <svg className="flex-1" xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 32 32"><title>Users SVG Icon</title><path fill="currentColor" d="M11.5 6A3.514 3.514 0 0 0 8 9.5c0 1.922 1.578 3.5 3.5 3.5S15 11.422 15 9.5S13.422 6 11.5 6m9 0A3.514 3.514 0 0 0 17 9.5c0 1.922 1.578 3.5 3.5 3.5S24 11.422 24 9.5S22.422 6 20.5 6m-9 2c.84 0 1.5.66 1.5 1.5s-.66 1.5-1.5 1.5s-1.5-.66-1.5-1.5s.66-1.5 1.5-1.5m9 0c.84 0 1.5.66 1.5 1.5s-.66 1.5-1.5 1.5s-1.5-.66-1.5-1.5s.66-1.5 1.5-1.5M7 12c-2.2 0-4 1.8-4 4c0 1.113.477 2.117 1.219 2.844A5.04 5.04 0 0 0 2 23h2c0-1.668 1.332-3 3-3s3 1.332 3 3h2a5.04 5.04 0 0 0-2.219-4.156C10.523 18.117 11 17.114 11 16c0-2.2-1.8-4-4-4m5 11c-.625.836-1 1.887-1 3h2c0-1.668 1.332-3 3-3s3 1.332 3 3h2a5.02 5.02 0 0 0-1-3c-.34-.453-.75-.84-1.219-1.156C19.523 21.117 20 20.114 20 19c0-2.2-1.8-4-4-4s-4 1.8-4 4c0 1.113.477 2.117 1.219 2.844A5 5 0 0 0 12 23m8 0h2c0-1.668 1.332-3 3-3s3 1.332 3 3h2a5.04 5.04 0 0 0-2.219-4.156C28.523 18.117 29 17.114 29 16c0-2.2-1.8-4-4-4s-4 1.8-4 4c0 1.113.477 2.117 1.219 2.844A5.04 5.04 0 0 0 20 23M7 14c1.117 0 2 .883 2 2s-.883 2-2 2s-2-.883-2-2s.883-2 2-2m18 0c1.117 0 2 .883 2 2s-.883 2-2 2s-2-.883-2-2s.883-2 2-2m-9 3c1.117 0 2 .883 2 2s-.883 2-2 2s-2-.883-2-2s.883-2 2-2" /></svg>
+            <div className="flex-2 flex flex-col justify-center gap-2">
+              <h3 className="font-bold">B. Talleres</h3>
+              <p>Espacios grupales de reflexión,
+                prevención y abordaje de las violencias.</p>
+            </div>
+          </div>
+        </article>
+        <article className="border-2 border-fara-blue text-fara-blue px-4 py-5 text-base shadow-md transition-colors md:p-8 md:text-xl hover:bg-fara-blue hover:text-white duration-300">
+          <div className="flex flex-col justify-center items-center gap-3 lg:flex-row">
+            <svg className="flex-1 lucide lucide-handshake-icon lucide-handshake" xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m11 17 2 2a1 1 0 1 0 3-3" /><path d="m14 14 2.5 2.5a1 1 0 1 0 3-3l-3.88-3.88a3 3 0 0 0-4.24 0l-.88.88a1 1 0 1 1-3-3l2.81-2.81a5.79 5.79 0 0 1 7.06-.87l.47.28a2 2 0 0 0 1.42.25L21 4" /><path d="m21 3 1 11h-2" /><path d="M3 3 2 14l6.5 6.5a1 1 0 1 0 3-3" /><path d="M3 4h8" /></svg>
+            <div className="flex-2 flex flex-col justify-center gap-2">
+              <h3 className="font-bold">C. Prácticas restaurativas</h3>
+              <p>Procesos restaurativos seguros,
+                adaptados y evaluados caso a caso.</p>
+            </div>
+          </div>
+        </article>
+        <article className="border-2 border-fara-blue text-fara-blue px-4 py-5 text-base shadow-md transition-colors md:p-8 md:text-xl hover:bg-fara-blue hover:text-white duration-300">
+          <div className="flex flex-col justify-center items-center gap-3 lg:flex-row">
+            <svg className="flex-1 lucide lucide-graduation-cap-icon lucide-graduation-cap" xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21.42 10.922a1 1 0 0 0-.019-1.838L12.83 5.18a2 2 0 0 0-1.66 0L2.6 9.08a1 1 0 0 0 0 1.832l8.57 3.908a2 2 0 0 0 1.66 0z" /><path d="M22 10v6" /><path d="M6 12.5V16a6 3 0 0 0 12 0v-3.5" /></svg>
+            <div className="flex-2 flex flex-col justify-center gap-2">
+              <h3 className="font-bold">D. Formación</h3>
+              <p>Capacitación a profesionales,
+                instituciones y organizaciones de la
+                sociedad civil.</p>
+            </div>
+          </div>
+        </article>
+        <article className="border-2 border-fara-blue text-fara-blue px-4 py-5 text-base shadow-md transition-colors md:p-8 md:text-xl hover:bg-fara-blue hover:text-white duration-300">
+          <div className="flex flex-col justify-center items-center gap-3 lg:flex-row">
+            <svg className="flex-1 lucide lucide-search-icon lucide-search" xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m21 21-4.34-4.34" /><circle cx="11" cy="11" r="8" /></svg>
+            <div className="flex-2 flex flex-col justify-center gap-2">
+              <h3 className="font-bold">E. Investigación</h3>
+              <p>Producción de conocimiento sobre
+                justicia restaurativa y género.</p>
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+  )
+}

--- a/src/components/sectionsFaraGenero/ProgramaEmpoderanos.jsx
+++ b/src/components/sectionsFaraGenero/ProgramaEmpoderanos.jsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { Link } from "react-router";
+
+export function ProgramaEmpoderanos() {
+  return (
+    <section className="flex flex-col justify-center items-center w-full gap-16 py-12 px-10 md:py-20 md:px-32">
+      <div className="flex flex-col items-center justify-center">
+        <h2 className="text-xl font-bold md:text-2xl lg:text-5xl mb-5 text-center">
+          Programa "Empoderarnos para Transformar"
+        </h2>
+        <p className="text-lg text-center max-w-3xl md:text-xl lg:text-2xl">
+          Programa territorial destinado a mujeres y diversidades, orientado al fortalecimiento personal, comunitario y jurídico desde una perspectiva restaurativa.
+        </p>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-2">
+        <span className="bg-fara-lime/30 px-4 py-5 text-base shadow-md transition-colors duration-300 text-center md:px-7 md:py-8 md:text-xl font-semibold">
+          Derechos de acción
+        </span>
+        <span className="bg-fara-lime/30 px-4 py-5 text-base shadow-md transition-colors duration-300 text-center md:px-7 md:py-8 md:text-xl font-semibold">
+          Redes de cuidado
+        </span>
+        <span className="bg-fara-lime/30 px-4 py-5 text-base shadow-md transition-colors duration-300 text-center md:px-7 md:py-8 md:text-xl font-semibold">
+          Salud mental integral
+        </span>
+        <span className="bg-fara-lime/30 px-4 py-5 text-base shadow-md transition-colors duration-300 text-center md:px-7 md:py-8 md:text-xl font-semibold">
+          Autonomía económica
+        </span>
+        <span className="bg-fara-lime/30 px-4 py-5 text-base shadow-md transition-colors duration-300 text-center md:px-7 md:py-8 md:text-xl font-semibold">
+          Acceso a la justicia
+        </span>
+        <span className="bg-fara-lime/30 px-4 py-5 text-base shadow-md transition-colors duration-300 text-center md:px-7 md:py-8 md:text-xl font-semibold">
+          Participación ciudadana
+        </span>
+      </div>
+
+      <Link
+        to="/capacitaciones"
+        className="skew-custom bg-fara-blue hover:bg-fara-cyan active:bg-fara-cyan focus:bg-fara-cyan text-center px-4 py-3 text-white uppercase shadow-2xl transition-colors duration-300 ease-in-out hover:cursor-pointer font-bold"
+      >
+        Conocer el programa
+      </Link>
+    </section>
+  )
+}

--- a/src/components/sectionsFaraGenero/RecursosInformativos.jsx
+++ b/src/components/sectionsFaraGenero/RecursosInformativos.jsx
@@ -1,0 +1,30 @@
+import { Link } from "react-router";
+
+export function RecursosInformativos() {
+  return (
+    <section className="flex flex-col justify-center items-center gap-4 py-12 px-10 md:py-20 md:px-32">
+      <div className="flex flex-col items-center justify-center">
+        <h2 className="text-xl font-bold md:text-2xl lg:text-5xl mb-5 text-center">
+          Recursos Informativos
+        </h2>
+        <p className="text-lg text-center max-w-4xl md:text-xl lg:text-2xl">
+          Puede solicitar artículos y orientación.
+        </p>
+      </div>
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <div className="border-2 border-fara-blue text-fara-blue px-4 py-5 text-base shadow-md md:p-8 md:text-xl">
+          <div className="flex flex-col justify-center gap-3">
+            <div className="flex-2 flex flex-col justify-center gap-2">
+              <h3 className="font-bold">Nombre del recurso</h3>
+              <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Velit, incidunt!</p>
+            </div>
+            <Link to={"/"} className="flex items-center hover:underline">
+              Link al recurso
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-arrow-right-icon lucide-arrow-right"><path d="M5 12h14" /><path d="m12 5 7 7-7 7" /></svg>
+            </Link>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary

PR 1 of 3 in the feature-branch-chain for **mejorar-accesibilidad-genero-page**. Fixes invalid HTML and critical ARIA gaps across 4 components.

### Changes

| Task | Component | What was done |
|------|-----------|--------------|
| 1.1 | LineaDeTrabajo | Replaced 5 invalid `<span>` wrappers (containing `<div>`/`<h3>`/`<p>`) with `<article>` elements; fixed duplicate `className` on SVGs |
| 1.2 | RecursosInformativos | Replaced invalid `<span>` (wrapping `<div>`/`<h3>`/`<p>`/`<Link>`) with `<div>` |
| 1.3 | EquipoDiciplinario | Added `aria-label` to 14 social `<a>` tags (LinkedIn + X); added `aria-hidden=true` and `focusable=false` to decorative SVGs; changed `key={index}` → `key={integrante.id}` |
| 1.4 | ProgramaEmpoderanos | Removed mismatched `aria-label="Solicitar Acompañamiento"` from "Conocer el programa" link (visible text is sufficient) |

### Files Modified

- `src/components/sectionsFaraGenero/LineaDeTrabajo.jsx`
- `src/components/sectionsFaraGenero/RecursosInformativos.jsx`
- `src/components/sectionsFaraGenero/EquipoDiciplinario.jsx`
- `src/components/sectionsFaraGenero/ProgramaEmpoderanos.jsx`

### Commits

1. `fix(a11y): replace invalid <span> with semantic elements in LineaDeTrabajo and RecursosInformativos`
2. `fix(a11y): add ARIA labels, hide decorative SVGs, and fix stable keys`

### Notes

- Gold contrast left for design to decide later (no changes in this PR)
- SVG `<title>` removal deferred to PR 2
- This is PR 1 → target is tracker branch `feat/a11y-genero-page`; PR 2 will target `feat/a11y-html-aria`